### PR TITLE
Run plugins concurrently with timeout

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -141,13 +141,36 @@ def load_plugins(plugin_names: List[str]) -> List[Any]:
 
 
 def run_plugins(plugins: List[Any], text: str, ctx: PluginCtx):
-    """Ejecuta plugins cuyo matcher devuelva True para el texto dado."""
+    """Ejecuta plugins cuyo matcher devuelva True para el texto dado.
+
+    Cada plugin se despacha en un ``thread`` independiente para que puedan
+    ejecutarse en paralelo. Se captura cualquier excepción de cada plugin y
+    se reporta si excede el ``timeout``.
+    """
+    threads = []
+
+    def _run(p, name):
+        try:
+            p.run(text, ctx)
+        except Exception as e:
+            logger.error(f"[Plugins] Error en {name}: {e}")
+
     for p in plugins:
+        name = getattr(p, 'name', '<plugin>')
         try:
             if p.match(text, ctx.config):
-                p.run(text, ctx)
+                t = threading.Thread(target=_run, args=(p, name), daemon=True)
+                t.start()
+                threads.append((t, name))
         except Exception as e:
-            logger.error(f"[Plugins] Error en {getattr(p,'name','<plugin>')}: {e}")
+            logger.error(f"[Plugins] Error en matcher {name}: {e}")
+
+    timeout = ctx.config.get('plugin_timeout_sec', 5.0)
+    for t, name in threads:
+        t.join(timeout)
+        if t.is_alive():
+            logger.error(f"[Plugins] Timeout en {name}")
+
     ctx.memory.add_history(text)
 
 

--- a/src/memory.py
+++ b/src/memory.py
@@ -1,11 +1,13 @@
 import yaml
 from pathlib import Path
 from typing import Any, Dict, List
+import threading
 
 class MemoryStore:
     """Almacén simple de memoria persistente en YAML."""
     def __init__(self, path: Path):
         self.path = path
+        self.lock = threading.RLock()
         if path.exists():
             with path.open('r', encoding='utf-8') as f:
                 self.data: Dict[str, Any] = yaml.safe_load(f) or {}
@@ -14,20 +16,25 @@ class MemoryStore:
         self.data.setdefault('history', [])
 
     def add_history(self, text: str) -> None:
-        self.data.setdefault('history', []).append(text)
-        self.save()
+        with self.lock:
+            self.data.setdefault('history', []).append(text)
+            self.save()
 
     def get_history(self) -> List[str]:
-        return list(self.data.get('history', []))
+        with self.lock:
+            return list(self.data.get('history', []))
 
     def set(self, key: str, value: Any) -> None:
-        self.data[key] = value
-        self.save()
+        with self.lock:
+            self.data[key] = value
+            self.save()
 
     def get(self, key: str, default: Any = None) -> Any:
-        return self.data.get(key, default)
+        with self.lock:
+            return self.data.get(key, default)
 
     def save(self) -> None:
-        with self.path.open('w', encoding='utf-8') as f:
-            yaml.safe_dump(self.data, f)
+        with self.lock:
+            with self.path.open('w', encoding='utf-8') as f:
+                yaml.safe_dump(self.data, f)
 


### PR DESCRIPTION
## Summary
- execute matched plugins in parallel threads with per-task timeout and error handling
- protect MemoryStore with an RLock to keep concurrent plugin access thread-safe

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_b_68b3130182948332a2f3fb2afbe02069